### PR TITLE
Fixed bugs with WMI output and code refactor

### DIFF
--- a/include/hwinfo/WMIwrapper.h
+++ b/include/hwinfo/WMIwrapper.h
@@ -121,7 +121,8 @@ inline bool queryWMI(const std::string &WMIClass,
 
   pSvc->Release();
   pLoc->Release();
-  pEnumerator->Release();
+  if (pEnumerator)
+      pEnumerator->Release();
   CoUninitialize();
   return true;
 }

--- a/include/hwinfo/utils/stringutils.h
+++ b/include/hwinfo/utils/stringutils.h
@@ -11,7 +11,6 @@
  * @param input
  */
 inline void strip(std::string& input) {
-  std::string res;
   size_t start_index = 0;
   while (true) {
     char c = input[start_index];

--- a/src/cpu.cpp
+++ b/src/cpu.cpp
@@ -18,9 +18,8 @@ CPU::CPU(std::string& model,
          int numPhysicalCores,
          int numLogicalCores,
          int maxClockSpeed_kHz,
-         int regularClockSpeed_kHz) {
-  _modelName = model;
-  _vendor = vendor;
+         int regularClockSpeed_kHz)
+  : _modelName(model), _vendor(vendor) {
   _cacheSize_Bytes = cacheSize_Bytes;
   _numPhysicalCores = numPhysicalCores;
   _numLogicalCores = numLogicalCores;

--- a/src/disk.cpp
+++ b/src/disk.cpp
@@ -7,10 +7,8 @@
 namespace hwinfo {
 
 // _____________________________________________________________________________________________________________________
-Disk::Disk(const std::string &vendor, const std::string &model, const std::string &serialNumber, int64_t size_Bytes) {
-  _vendor = vendor;
-  _model = model;
-  _serialNumber = serialNumber;
+Disk::Disk(const std::string &vendor, const std::string &model, const std::string &serialNumber, int64_t size_Bytes)
+  : _vendor(vendor), _model(model), _serialNumber(serialNumber) {
   _size_Bytes = size_Bytes;
 }
 

--- a/src/gpu.cpp
+++ b/src/gpu.cpp
@@ -18,10 +18,8 @@
 namespace hwinfo {
 
 // _____________________________________________________________________________________________________________________
-GPU::GPU(const std::string& vendor, const std::string &name, const std::string &driverVersion, int64_t memory_Bytes) {
-  _vendor = vendor;
-  _name = name;
-  _driverVersion = driverVersion;
+GPU::GPU(const std::string& vendor, const std::string &name, const std::string &driverVersion, int64_t memory_Bytes)
+  : _vendor(vendor), _name(name), _driverVersion(driverVersion) {
   _memory_Bytes = memory_Bytes;
 }
 

--- a/src/mainboard.cpp
+++ b/src/mainboard.cpp
@@ -14,11 +14,8 @@ namespace hwinfo {
 MainBoard::MainBoard(const std::string &vendor,
                      const std::string &product,
                      const std::string &version,
-                     const std::string &serialNumber) {
-  _vendor = vendor;
-  _name = product;
-  _version = version;
-  _serialNumber = serialNumber;
+                     const std::string &serialNumber)
+  : _vendor(vendor), _name(product), _version(version), _serialNumber(serialNumber) {
 }
 
 // _____________________________________________________________________________________________________________________

--- a/src/ram.cpp
+++ b/src/ram.cpp
@@ -21,11 +21,8 @@ RAM::RAM(std::string &vendor,
          std::string &name,
          std::string &model,
          std::string &serialNumber,
-         int64_t size_Bytes) {
-  _vendor = vendor;
-  _name = name;
-  _model = model;
-  _serialNumber = serialNumber;
+         int64_t size_Bytes)
+  : _vendor(vendor), _name(name), _model(model), _serialNumber(serialNumber) {
   _totalSize_Bytes = size_Bytes;
 }
 

--- a/src/windows/cpu.cpp
+++ b/src/windows/cpu.cpp
@@ -121,9 +121,7 @@ int CPU::getNumPhysicalCores() {
       cpuid::cpuid(0x80000000, 0, regs_4);
       if (regs_4[0] >= 8) {
         int numCores = 1 + (regs_4[2] & 0xff);
-        if (numCores > 0) {
-          return numCores;
-        }
+        return numCores;
       }
     }
   }

--- a/src/windows/cpu.cpp
+++ b/src/windows/cpu.cpp
@@ -182,7 +182,7 @@ int CPU::getMaxClockSpeed_kHz() {
 // _____________________________________________________________________________________________________________________
 int CPU::getRegularClockSpeed_kHz() {
   std::vector<int64_t> speed {};
-  wmi::queryWMI("Win32_Processor", "MaxClockSpeed", speed);
+  wmi::queryWMI("Win32_Processor", "CurrentClockSpeed", speed);
   if (speed.empty()) { return -1; }
   return speed[0] * 1000;
 }

--- a/src/windows/disk.cpp
+++ b/src/windows/disk.cpp
@@ -19,7 +19,6 @@ std::vector<Disk> getAllDisks() {
   std::vector<const wchar_t*> vendor {};
   wmi::queryWMI("Win32_Processor", "Name", vendor);
   if (vendor.empty()) { return {}; }
-  std::wstring tmp(vendor[0]);
   return disks;
 }
 

--- a/src/windows/gpu.cpp
+++ b/src/windows/gpu.cpp
@@ -17,9 +17,9 @@ namespace hwinfo {
 
 // _____________________________________________________________________________________________________________________
 std::string GPU::getVendor() {
-  std::vector<const wchar_t*> names{};
-  wmi::queryWMI("WIN32_VideoController", "Name", names);
-  auto ret = names[0];
+  std::vector<const wchar_t*> vendor{};
+  wmi::queryWMI("WIN32_VideoController", "AdapterCompatibility", vendor);
+  auto ret = vendor[0];
   if (!ret) {
     return "<unknown>";
   }


### PR DESCRIPTION
- Fixed bug with output GPU Vendor

  Example difference:
  ![image](https://user-images.githubusercontent.com/21138600/188902321-88649f6a-1846-4102-855c-65e68b0033ee.png)
  
  and other logs
```
instance of Win32_VideoController
{
    AdapterCompatibility = "Intel Corporation";
    AdapterDACType = "Internal";
    AdapterRAM = 1073741824;
    Availability = 3;
    Caption = "Intel(R) HD Graphics 4600";
    ConfigManagerErrorCode = 0;
    ConfigManagerUserConfig = FALSE;
    CreationClassName = "Win32_VideoController";
    CurrentBitsPerPixel = 32;
    CurrentHorizontalResolution = 1920;
    CurrentNumberOfColors = "4294967296";
    CurrentNumberOfColumns = 0;
    CurrentNumberOfRows = 0;
    CurrentRefreshRate = 59;
    CurrentScanMode = 4;
    CurrentVerticalResolution = 1080;
    Description = "Intel(R) HD Graphics 4600";
    DeviceID = "VideoController1";
    DitherType = 0;
    DriverDate = "20150911000000.000000-000";
    DriverVersion = "20.19.15.4285";
    InfFilename = "oem79.inf";
    InfSection = "iHSWD_w10";
    InstalledDisplayDrivers = "igdumdim64.dll,igd10iumd64.dll,igd10iumd64.dll,igd12umd64.dll,igdumdim32,igd10iumd32,igd10iumd32,igd12umd32";
    MaxRefreshRate = 75;
    MinRefreshRate = 50;
    Monochrome = FALSE;
    Name = "Intel(R) HD Graphics 4600";
    PNPDeviceID = "PCI\\VEN_8086&DEV_0412&SUBSYS_18E5103C&REV_06\\3&11583659&0&10";
    Status = "OK";
    SystemCreationClassName = "Win32_ComputerSystem";
    SystemName = "---------";
    VideoArchitecture = 5;
    VideoMemoryType = 2;
    VideoModeDescription = "1920 x 1080 x 4294967296 colors";
    VideoProcessor = "Intel(R) HD Graphics Family";
};

instance of Win32_PnPEntity
{
    Caption = "Intel(R) HD Graphics 4600";
    ClassGuid = "{4d36e968-e325-11ce-bfc1-08002be10318}";
    CompatibleID = {"PCI\\VEN_8086&DEV_0412&REV_06", "PCI\\VEN_8086&DEV_0412", "PCI\\VEN_8086&CC_030000", "PCI\\VEN_8086&CC_0300", "PCI\\VEN_8086", "PCI\\CC_030000", "PCI\\CC_0300"};
    ConfigManagerErrorCode = 0;
    ConfigManagerUserConfig = FALSE;
    CreationClassName = "Win32_PnPEntity";
    Description = "Intel(R) HD Graphics 4600";
    DeviceID = "PCI\\VEN_8086&DEV_0412&SUBSYS_18E5103C&REV_06\\3&11583659&0&10";
    HardwareID = {"PCI\\VEN_8086&DEV_0412&SUBSYS_18E5103C&REV_06", "PCI\\VEN_8086&DEV_0412&SUBSYS_18E5103C", "PCI\\VEN_8086&DEV_0412&CC_030000", "PCI\\VEN_8086&DEV_0412&CC_0300"};
    Manufacturer = "Intel Corporation";
    Name = "Intel(R) HD Graphics 4600";
    PNPClass = "Display";
    PNPDeviceID = "PCI\\VEN_8086&DEV_0412&SUBSYS_18E5103C&REV_06\\3&11583659&0&10";
    Present = TRUE;
    Service = "igfx";
    Status = "OK";
    SystemCreationClassName = "Win32_ComputerSystem";
    SystemName = "-------";
};
```

- Fixed CPU CurrentClockSpeed
- Fixed might be dereferencing of a potential null pointer 'pEnumerator'
- Removed unused vars
- Optimize more efficient to use an initialization list in constuctors
- Fixed `numCores > 0` always true

   `regs_4[2]` will never be negative, and other `int` values are always positive
   
   Example:
```
int numCores = (int) + (uint32_t && int)
```
