### PR TITLE
Fix cache size calculation on windows

### DIFF
--- a/src/windows/cpu.cpp
+++ b/src/windows/cpu.cpp
@@ -202,7 +202,7 @@ int CPU::getCacheSize_Bytes() {
   if (cacheSize.empty()) {
     return -1;
   }
-  return cacheSize[0];
+  return cacheSize[0] * 1024;
 }
 
 // =====================================================================================================================


### PR DESCRIPTION
According to https://powershell.one/wmi/root/cimv2/win32_processor the cache size returned by WMI is in kilobytes.

I verified on my system that the outputted cache size is wrong by a factor of 1024.

Output before: `cache size:         25344`
Output after: `cache size:         25952256`

