### PR TITLE
Add support for gcc version 8 to 9.1 and clang version 7 to 9

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,13 @@ include_directories(${PROJECT_SOURCE_DIR}/include/)
 
 add_subdirectory(src)
 
+if(("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND
+    ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "8" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "9.1") OR
+("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+    ${CMAKE_CXX_COMPILER_VERSION} VERSION_GREATER_EQUAL "7" AND ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "9"))
+    target_link_libraries(HWinfo PUBLIC "stdc++fs")
+endif()
+
 if (${MAIN_PROJECT})
     add_subdirectory(examples)
     add_subdirectory(test)


### PR DESCRIPTION
GCC versions greater than or equal to 8 and less than 9.1, and Clang versions greater than or equal to 7 and less than 9, need 
`-lstdc++fs` to use `std::filesystem`.