### PR TITLE
Implement available memory size module for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ CPU, RAM, GPU, Disks, Mainboard, ...
 |                  | Name               |   ❌    |   ❌   |   ✔️    | `RAM::getName()`                                                      |
 |                  | Serial Number      |   ❌    |   ❌   |   ✔️    | `RAM::get()`                                                          |
 |                  | Total Memory Size  |   ✔️   |  ✔️   |   ✔️    | `RAM::getTotalSizes_Bytes()`                                          |
-|                  | Free Memory Size   |   ✔️   |   ❌   |    ❌    | `-`                                                                   |
+|                  | Free Memory Size   |   ✔️   |   ❌   |    ✔️    | `RAM::getAvailableMemory()`                                                                   |
 | Mainboard        | Vendor             |   ✔️   |   ❌   |   ✔️    | `MainBoard::getVendor()`                                              |
 |                  | Model              |   ✔️   |   ❌   |   ✔️    | `MainBoard::getName()`                                                |
 |                  | Version            |   ✔️   |   ❌   |   ✔️    | `MainBoard::getVersion()`                                             |

--- a/src/windows/ram.cpp
+++ b/src/windows/ram.cpp
@@ -83,18 +83,10 @@ int64_t RAM::getTotalSize_Bytes() {
 
 // _____________________________________________________________________________________________________________________
 int64_t RAM::getAvailableMemory() {
-  // it will return L"FreePhysicalMemory" Str
-  std::vector<wchar_t*> memories{};
-  // Number of kilobytes of physical memory currently unused and available.
-  wmi::queryWMI("CIM_OperatingSystem", "FreePhysicalMemory", memories);
-  if (memories.size() > 0) {
-    if (memories.front() == nullptr) {
-      return -1;
-    }
-    // keep it as totalSize_Bytes
-    return std::stoll(wstring_to_std_string(memories[0])) * 1024;
-  }
-  return -1;
+  MEMORYSTATUSEX status;
+  status.dwLength = sizeof(status);
+  GlobalMemoryStatusEx(&status);
+  return static_cast<int64_t>(status.ullAvailPhys);
 }
 
 }  // namespace hwinfo


### PR DESCRIPTION
The previous implementation was returning -1 on Windows, so I fixed it.
Also I changed the README for it to display the support of the new feature.