### PR TITLE
Lower required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 project(hwinfo VERSION 1.0.0 LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 11)


### PR DESCRIPTION
Probably even older versions than 3.16 will work but 3.21 requirement is too high for some systems. 3.16 is just a suggestion, for example if you plan to add unit tests by using an environment/framework the choosing the same version requirement of the framework should be better. For example, for GoogleTest it is 3.5 https://github.com/google/googletest/blob/main/CMakeLists.txt