### PR TITLE
fix:GPU_CL and func get_cpu_cl_data() out of range

### DIFF
--- a/include/hwinfo/gpu.h
+++ b/include/hwinfo/gpu.h
@@ -49,7 +49,7 @@ class GPU {
 };
 
 std::vector<GPU> getAllGPUs();
-
+#ifdef USE_OCL
 std::vector<GPU_CL> get_cpu_cl_data();
-
+#endif
 }  // namespace hwinfo


### PR DESCRIPTION
 Beyond the scope of the macro definition USE_OCL