### PR TITLE
Update os.cpp

### DIFF
--- a/src/windows/os.cpp
+++ b/src/windows/os.cpp
@@ -44,7 +44,7 @@ OS::OS() {
   }
   hr = obj->Get(L"OSArchitecture", 0, &vt_prop, nullptr, nullptr);
   if (SUCCEEDED(hr)) {
-    _64bit = utils::wstring_to_std_string(vt_prop.bstrVal) == "64-bit";
+    _64bit = utils::wstring_to_std_string(vt_prop.bstrVal).find("64") != std::string::npos;
     _32bit = !_64bit;
   }
   hr = obj->Get(L"BuildNumber", 0, &vt_prop, nullptr, nullptr);


### PR DESCRIPTION
may have problem in other language environments, for example "64位"
original code:
![Snipaste_2023-10-23_13-37-57](https://github.com/lfreist/hwinfo/assets/35524499/9fe8490e-7ae6-4835-93b6-5b53be5653b2)
output:
![Snipaste_2023-10-23_13-38-39](https://github.com/lfreist/hwinfo/assets/35524499/1100a452-9348-4739-a20b-1d881cd432c3)
what I get with powershell
![Snipaste_2023-10-23_13-39-01](https://github.com/lfreist/hwinfo/assets/35524499/ee9fcc24-3be6-4957-8983-39e470898859)
