### PR TITLE
Suggestion for Windows, CI, and CMake

### DIFF
--- a/.github/workflows/build-windows-vs.yml
+++ b/.github/workflows/build-windows-vs.yml
@@ -10,13 +10,12 @@ jobs:
   build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
 
       - name: Setup Visual Studio
         uses: egor-tensin/vs-shell@v2
-
-      - name: Setup gitmodules
-        run: git submodule update --init --recursive
 
       - name: Configure CMake
         run: cmake -B ${{github.workspace}}\build -DCMAKE_BUILD_TYPE=Release -UOPENCL_SDK_BUILD_SAMPLES -DNO_OCL=ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,9 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.21)
 project(hwinfo VERSION 1.0.0 LANGUAGES CXX)
+include(GNUInstallDirs)
+
+option(BUILD_EXAMPLES "Build example program" ${PROJECT_IS_TOP_LEVEL})
+option(BUILD_TESTING  "Build test program" ${PROJECT_IS_TOP_LEVEL})
 
 # set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 
@@ -12,12 +16,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-
-set(MAIN_PROJECT OFF)
-if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    set(MAIN_PROJECT ON)
-endif()
-
 
 if (NOT DEFINED NO_OCL)
     set(OPENCL_SDK_BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
@@ -35,15 +33,22 @@ include_directories({PROJECT_SOURCE_DIR}/include)
 add_subdirectory(src)
 target_include_directories(HWinfo PUBLIC ${PROJECT_SOURCE_DIR}/include/)
 
+install(DIRECTORY include/hwinfo DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
 if (CMAKE_HOST_SYSTEM_NAME STREQUAL "Linux")
     file(COPY "scripts/pci.ids" DESTINATION "$ENV{HOME}/.hwinfo/")
 endif ()
 
-if (${MAIN_PROJECT})
-    add_subdirectory(examples)
+if (NOT PROJECT_IS_TOP_LEVEL)
+    return()
+endif()
 
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+if(BUILD_TESTING)
     include(CTest)
     add_subdirectory(test)
-
     add_test(Example examples/Example)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
-cmake_minimum_required(VERSION 3.21)
+cmake_minimum_required(VERSION 3.16)
 project(hwinfo VERSION 1.0.0 LANGUAGES CXX)
 include(GNUInstallDirs)
+
+string(COMPARE EQUAL "${CMAKE_SOURCE_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}" PROJECT_IS_TOP_LEVEL)
 
 option(BUILD_EXAMPLES "Build example program" ${PROJECT_IS_TOP_LEVEL})
 option(BUILD_TESTING  "Build test program" ${PROJECT_IS_TOP_LEVEL})

--- a/examples/example.cpp
+++ b/examples/example.cpp
@@ -149,4 +149,5 @@ int main(int argc, char** argv) {
   } else {
     std::cout << "No Disks installed or detected" << std::endl;
   }
+  return EXIT_SUCCESS;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,3 +48,5 @@ if (NOT DEFINED NO_OCL)
 endif ()
 
 add_library(${PROJECT_NAME}::HWinfo ALIAS HWinfo)
+
+install(TARGETS HWinfo DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/windows/disk.cpp
+++ b/src/windows/disk.cpp
@@ -45,7 +45,8 @@ std::vector<Disk> getAllDisks() {
     }
     hr = obj->Get(L"SerialNumber", 0, &vt_prop, nullptr, nullptr);
     if (SUCCEEDED(hr)) {
-      disk._serialNumber = utils::wstring_to_std_string(vt_prop.bstrVal);
+      if (vt_prop.bstrVal)  // the value may empty
+        disk._serialNumber = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"Size", 0, &vt_prop, nullptr, nullptr);
     if (SUCCEEDED(hr)) {


### PR DESCRIPTION
Hi @lfreist , appreciate your great work.
I'm reviewing the internals before suggesting this project to https://github.com/microsoft/vcpkg

These are my ideas for future maintenance. Would you consider it?

## Changes

### GitHub Actions

* Bump the `actions/checkout`'s version
* After Git checkout, fetch Git submodules

### CMake

* Mock https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html in CMake 3.21+
   * Replaces `MAIN_PROJECT`
* New build `option`s
   * `BUILD_TESTING`
   * `BUILD_EXAMPLES`
* Support `install` target
   * Install headers under `${prefix}/include`
   * Install libraries under `${prefix}/lib`

### Example

Return `0` for `int main(...)`

### WMI(Windows Management Instrumentation)

In `main` branch, CI fails because `SerialNumber` is empty.
Added `nullptr` check in several points.
