### PR TITLE
Fixed OS version querying on Linux

### DIFF
--- a/src/linux/os.cpp
+++ b/src/linux/os.cpp
@@ -32,7 +32,7 @@ OS::OS() {
         // remove \" at begin and end of the substring result
         _name = {line.begin() + 1, line.end() - 1};
       }
-      if (utils::starts_with(line, "VERSION")) {
+      if (utils::starts_with(line, "VERSION=")) {
         line = line.substr(line.find('=') + 1, line.length());
         // remove \" at begin and end of the substring result
         _version = {line.begin() + 1, line.end() - 1};


### PR DESCRIPTION
OS version querying on Linux works by reading the property that starts with `VERSION` in the file `/etc/os-release`. My Ubuntu system however contains the following in that file

```
VERSION_ID="23.04"
VERSION="23.04 (Lunar Lobster)"
VERSION_CODENAME=lunar
```

This causes the version number to be set to `una` which is the value of the last property that starts with `VERSION` minus the first and last character.

I also suggest applying a similar fix for all situations where we read from this file or a similar one to avoid future issues.