### PR TITLE
Fix: segfault on Windows due to faulty variant access

### DIFF
--- a/src/windows/disk.cpp
+++ b/src/windows/disk.cpp
@@ -50,7 +50,7 @@ std::vector<Disk> getAllDisks() {
     }
     hr = obj->Get(L"Size", 0, &vt_prop, nullptr, nullptr);
     if (SUCCEEDED(hr)) {
-      disk._size_Bytes = std::stoll(utils::wstring_to_std_string(vt_prop.bstrVal));
+      disk._size_Bytes = static_cast<int64_t>(vt_prop.ullVal);
     }
     VariantClear(&vt_prop);
     obj->Release();


### PR DESCRIPTION
`Win32_DiskDrive.Size` is a `uint64`, but was being accessed as string value, which resulted in a nullptr dereference.

Hope the `static_cast` is fine, otherwise you'd need to change the type to an `uint64_t`.