### PR TITLE
Windows: Ensure returned value type is checked

### DIFF
--- a/src/windows/battery.cpp
+++ b/src/windows/battery.cpp
@@ -29,7 +29,7 @@ std::string Battery::getSerialNumber() const { return "<unknwon>"; }
 std::string Battery::getTechnology() const { return "<unknwon>"; }
 
 // _____________________________________________________________________________________________________________________
-uint32_t Battery::getEnergyFull() const { return 0; }
+uint32_t Battery::getEnergyFull() const { return 1; }
 
 // _____________________________________________________________________________________________________________________
 uint32_t Battery::energyNow() const { return 0; }
@@ -64,15 +64,15 @@ std::vector<Battery> getAllBatteries() {
     VARIANT vt_prop;
     HRESULT hr;
     hr = obj->Get(L"Name", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       battery._model = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"FullChargeCapacity", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_I4)) {
       battery._energyFull = vt_prop.uintVal;
     }
     hr = obj->Get(L"DeviceID", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       battery._serialNumber = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     VariantClear(&vt_prop);

--- a/src/windows/cpu.cpp
+++ b/src/windows/cpu.cpp
@@ -112,23 +112,23 @@ std::vector<CPU> getAllCPUs() {
     VARIANT vt_prop;
     HRESULT hr;
     hr = obj->Get(L"Name", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       cpu._modelName = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"Manufacturer", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       cpu._vendor = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"NumberOfCores", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_I4)) {
       cpu._numPhysicalCores = vt_prop.intVal;
     }
     hr = obj->Get(L"NumberOfLogicalProcessors", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_I4)) {
       cpu._numLogicalCores = vt_prop.intVal;
     }
     hr = obj->Get(L"MaxClockSpeed", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_I4)) {
       cpu._maxClockSpeed_MHz = vt_prop.uintVal;
       cpu._regularClockSpeed_MHz = vt_prop.uintVal;
     }

--- a/src/windows/disk.cpp
+++ b/src/windows/disk.cpp
@@ -36,21 +36,20 @@ std::vector<Disk> getAllDisks() {
     VARIANT vt_prop;
     HRESULT hr;
     hr = obj->Get(L"Model", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       disk._model = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"Manufacturer", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       disk._vendor = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"SerialNumber", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
-      if (vt_prop.bstrVal)  // the value may empty
-        disk._serialNumber = utils::wstring_to_std_string(vt_prop.bstrVal);
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
+      disk._serialNumber = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"Size", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
-      disk._size_Bytes = static_cast<int64_t>(vt_prop.ullVal);
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
+      disk._size_Bytes = std::stoll(utils::wstring_to_std_string(vt_prop.bstrVal));
     }
     VariantClear(&vt_prop);
     obj->Release();

--- a/src/windows/gpu.cpp
+++ b/src/windows/gpu.cpp
@@ -45,23 +45,23 @@ std::vector<GPU> getAllGPUs() {
     VARIANT vt_prop;
     HRESULT hr;
     hr = obj->Get(L"Name", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       gpu._name = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"AdapterCompatibility", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       gpu._vendor = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"DriverVersion", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       gpu._driverVersion = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"AdapterRam", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_I4)) {
       gpu._memory_Bytes = vt_prop.uintVal;
     }
     hr = obj->Get(L"PNPDeviceID", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       std::string ret = utils::wstring_to_std_string(vt_prop.bstrVal);
       if (utils::starts_with(ret, "PCI\\")) {
         utils::replaceOnce(ret, "PCI\\", "");

--- a/src/windows/mainboard.cpp
+++ b/src/windows/mainboard.cpp
@@ -30,19 +30,19 @@ MainBoard::MainBoard() {
   VARIANT vt_prop;
   HRESULT hr;
   hr = obj->Get(L"Manufacturer", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _vendor = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   hr = obj->Get(L"Product", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _name = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   hr = obj->Get(L"Version", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _version = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   hr = obj->Get(L"SerialNumber", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _serialNumber = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   VariantClear(&vt_prop);

--- a/src/windows/os.cpp
+++ b/src/windows/os.cpp
@@ -39,20 +39,20 @@ OS::OS() {
   VARIANT vt_prop;
   HRESULT hr;
   hr = obj->Get(L"Caption", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _name = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   hr = obj->Get(L"OSArchitecture", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _64bit = utils::wstring_to_std_string(vt_prop.bstrVal).find("64") != std::string::npos;
     _32bit = !_64bit;
   }
   hr = obj->Get(L"BuildNumber", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _version = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   hr = obj->Get(L"Version", 0, &vt_prop, nullptr, nullptr);
-  if (SUCCEEDED(hr)) {
+  if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
     _kernel = utils::wstring_to_std_string(vt_prop.bstrVal);
   }
   VariantClear(&vt_prop);

--- a/src/windows/ram.cpp
+++ b/src/windows/ram.cpp
@@ -37,26 +37,26 @@ Memory::Memory() {
     Memory::Module module;
     module.id = id++;
     hr = obj->Get(L"Manufacturer", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       module.vendor = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     hr = obj->Get(L"partNumber", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       module.model = utils::wstring_to_std_string(vt_prop.bstrVal);
       // TODO: One expects an actual name of the RAM but wmi does not provide such a property...
       //       The "Name"-property of WMI returns "PhysicalMemory".
       module.name = std::string(module.vendor + " " + module.model);
     }
     hr = obj->Get(L"Capacity", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       module.total_Bytes = std::stoll(utils::wstring_to_std_string(vt_prop.bstrVal));
     }
     hr = obj->Get(L"ConfiguredClockSpeed", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
-      module.frequency_Hz = static_cast<int64_t>(vt_prop.ulVal) * 1000 * 1000;
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_I4)) {
+      module.frequency_Hz = static_cast<int64_t>(vt_prop.intVal) * 1000 * 1000;
     }
     hr = obj->Get(L"SerialNumber", 0, &vt_prop, nullptr, nullptr);
-    if (SUCCEEDED(hr)) {
+    if (SUCCEEDED(hr) && (V_VT(&vt_prop) == VT_BSTR)) {
       module.serial_number = utils::wstring_to_std_string(vt_prop.bstrVal);
     }
     VariantClear(&vt_prop);


### PR DESCRIPTION
I'm opening this PR because I got a report from a user that was not able to get the RAM SerialNumber, and others having various sporadic issue also around RAM across other fields. This made me wonder how the code is shielding and making sure that only when the value is a valid one is being used.

Checking just the result of the `hr` unfortunately is not enough as the call my succeed but the value of the string but be NULL, so an additional check is required [as per documentation](https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get#examples).

So by following that I added those checks in all windows entries where we query information via the WMI layer.

While doing so, and running the example project I noticed that the Capacity for the Battery was always returning `-nan` for Windows, which to my own surprise I found out the values are hardcoded. Not focusing on fixing this part, atm I just made sure the calculation returns 0, instead of `-nan`.

Finally also while running the test and checking information I found out that the Disk size was reported incorrectly as the `Size` field is a string, not an integer, for some reason so I'm parsing and converting that to a valid integer. Now the disk size in bytes is reported correctly.