### PR TITLE
fix: resolve compiler warnings

### DIFF
--- a/include/hwinfo/utils/stringutils.h
+++ b/include/hwinfo/utils/stringutils.h
@@ -150,7 +150,7 @@ inline std::vector<std::string> split(const std::string& input, const char delim
 inline std::string split_get_index(const std::string& input, const std::string& delimiter, int index) {
   unsigned occ = count_substring(input, delimiter) + 1;
   index = index < 0 ? static_cast<int>(occ + index) : index;
-  if (occ <= index) {
+  if (static_cast<int>(occ) <= index) {
     return "";
   }
 

--- a/src/linux/ram.cpp
+++ b/src/linux/ram.cpp
@@ -43,7 +43,6 @@ void set_value(std::string& line, int64_t* dst) {
     if (space != std::string::npos) {
       auto a = std::string(value.begin(), value.begin() + static_cast<int64_t>(space));
       *dst = (std::stoll(a) * 1024);
-      int i = 0;
     }
   }
 }


### PR DESCRIPTION
Resolves two compiler warnings due to:
- unused variable
- comparing unsigned with signed int

Specifically:
- warning: unused variable ‘i’ [-Wunused-variable]
- warning: comparison of integer expressions of different signedness: ‘unsigned int’ and ‘int’ [-Wsign-compare]