### PR TITLE
Mac: add battery capacity, charging status and serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,44 +35,44 @@ hwinfo builds using C++20. However, if your compiler does not support C++20, you
 > The listed components that are not yet implemented (indicated with ❌) are in development and will be supported in
 > later releases. **You are welcome to start contributing and help improving this library!**
 
-| Component        | Info               | Linux | Apple | Windows |
-|------------------|:-------------------|:-----:|:-----:|:-------:|
-| CPU              | Vendor             |  ✔️   |  ❌️   |   ✔️    |
-|                  | Model              |  ✔️   |  ✔️   |   ✔️    |
-|                  | Frequency          |  ✔️   |  ❌️   |   ✔️    |
-|                  | Physical Cores     |  ✔️   |  ✔️   |   ✔️    |
-|                  | Logical Cores      |  ✔️   |  ✔️   |   ✔️    |
-|                  | Cache Size         |  ✔️   |  ❌️   |   ✔️    |
-| GPU              | Vendor             |  ✔️   |  ❌️   |   ✔️    |
-|                  | Model              |  ✔️   |  ❌️   |   ✔️    |
-|                  | Memory Size        |   ❌   |   ❌   |   ✔️    |
-| Memory (RAM)     | Vendor             |   ❌   |   ❌   |   ✔️    |
-|                  | Model              |   ❌   |   ❌   |   ✔️    |
-|                  | Name               |   ❌   |   ❌   |   ✔️    |
-|                  | Serial Number      |   ❌   |   ❌   |   ✔️    |
-|                  | Total Memory Size  |  ✔️   |  ✔️   |   ✔️    |
-|                  | Free Memory Size   |  ✔️   |   ❌   |    ❌    |
-| Mainboard        | Vendor             |  ✔️   |   ❌   |   ✔️    |
-|                  | Model              |  ✔️   |   ❌   |   ✔️    |
-|                  | Version            |  ✔️   |   ❌   |   ✔️    |
-|                  | Serial-Number      |   ❌   |   ❌   |   ✔️    |
-|                  | Bios               |   ❌   |   ❌   |    ❌    |
-| Disk             | Vendor             |  ✔️   |  ✔️   |   ✔️    |
-|                  | Model              |  ✔️   |  ✔️   |   ✔️    |
-|                  | Serial-Number      |  ✔️   |  ✔️   |   ✔️    |
-|                  | Size               |  ✔️   |  ✔️   |   ✔️    |
-| Operating System | Name               |  ✔️   |  ✔️   |   ✔️    |
-|                  | Short Name         |  ✔️   |  ❌️   |   ✔️    |
-|                  | Version            |  ✔️   |  ✔️   |    ❌    |
-|                  | Kernel             |  ✔️   |  ✔️   |    ❌    |
-|                  | Architecture (Bit) |  ✔️   |  ✔️   |   ✔️    |
-|                  | Endianess          |  ✔️   |  ✔️   |   ✔️    |
-| Battery          | Vendor             |  ✔️   |   ❌   |    ❌    |
-|                  | Model              |  ✔️   |   ❌   |    ❌    |
-|                  | Serial Number      |  ✔️   |   ❌   |    ❌    |
-|                  | Technology         |  ✔️   |   ❌   |    ❌    |
-|                  | Capacity           |  ✔️   |   ❌   |   ️❌    |
-|                  | Charging           |  ✔️   |   ❌   |    ❌    |
+| Component        | Info               | Linux | Apple  | Windows |
+|------------------|:-------------------|:-----:|:------:|:-------:|
+| CPU              | Vendor             |  ✔️   |   ❌️   |   ✔️    |
+|                  | Model              |  ✔️   |   ✔️   |   ✔️    |
+|                  | Frequency          |  ✔️   |   ❌️   |   ✔️    |
+|                  | Physical Cores     |  ✔️   |   ✔️   |   ✔️    |
+|                  | Logical Cores      |  ✔️   |   ✔️   |   ✔️    |
+|                  | Cache Size         |  ✔️   |   ❌️   |   ✔️    |
+| GPU              | Vendor             |  ✔️   |   ❌️   |   ✔️    |
+|                  | Model              |  ✔️   |   ❌️   |   ✔️    |
+|                  | Memory Size        |   ❌   |   ❌    |   ✔️    |
+| Memory (RAM)     | Vendor             |   ❌   |   ❌    |   ✔️    |
+|                  | Model              |   ❌   |   ❌    |   ✔️    |
+|                  | Name               |   ❌   |   ❌    |   ✔️    |
+|                  | Serial Number      |   ❌   |   ❌    |   ✔️    |
+|                  | Total Memory Size  |  ✔️   |   ✔️   |   ✔️    |
+|                  | Free Memory Size   |  ✔️   |   ❌    |    ❌    |
+| Mainboard        | Vendor             |  ✔️   |   ❌    |   ✔️    |
+|                  | Model              |  ✔️   |   ❌    |   ✔️    |
+|                  | Version            |  ✔️   |   ❌    |   ✔️    |
+|                  | Serial-Number      |   ❌   |   ❌    |   ✔️    |
+|                  | Bios               |   ❌   |   ❌    |    ❌    |
+| Disk             | Vendor             |  ✔️   |   ✔️   |   ✔️    |
+|                  | Model              |  ✔️   |   ✔️   |   ✔️    |
+|                  | Serial-Number      |  ✔️   |   ✔️   |   ✔️    |
+|                  | Size               |  ✔️   |   ✔️   |   ✔️    |
+| Operating System | Name               |  ✔️   |   ✔️   |   ✔️    |
+|                  | Short Name         |  ✔️   |   ❌️   |   ✔️    |
+|                  | Version            |  ✔️   |   ✔️   |    ❌    |
+|                  | Kernel             |  ✔️   |   ✔️   |    ❌    |
+|                  | Architecture (Bit) |  ✔️   |   ✔️   |   ✔️    |
+|                  | Endianess          |  ✔️   |   ✔️   |   ✔️    |
+| Battery          | Vendor             |  ✔️   |   ❌️   |    ❌    |
+|                  | Model              |  ✔️   |   ❌    |    ❌    |
+|                  | Serial Number      |  ✔️   |   ✔️   |    ❌    |
+|                  | Technology         |  ✔️   |   ❌    |    ❌    |
+|                  | Capacity           |  ✔️   |   ✔️   |   ️❌    |
+|                  | Charging           |  ✔️   |   ✔️   |    ❌    |
 
 ## API
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,12 +51,6 @@ if (NOT DEFINED NO_OCL)
     target_link_libraries(HWinfo PUBLIC miss-opencl_static)
 endif ()
 
-if(APPLE)
-    find_library(IOKIT_LIBRARY IOKit)
-    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-    target_link_libraries(HWinfo PUBLIC ${IOKIT_LIBRARY} ${COREFOUNDATION_LIBRARY})
-endif()
-
 add_library(${PROJECT_NAME}::HWinfo ALIAS HWinfo)
 
 install(TARGETS HWinfo DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,6 +51,12 @@ if (NOT DEFINED NO_OCL)
     target_link_libraries(HWinfo PUBLIC miss-opencl_static)
 endif ()
 
+if(APPLE)
+    find_library(IOKIT_LIBRARY IOKit)
+    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+    target_link_libraries(HWinfo PUBLIC ${IOKIT_LIBRARY} ${COREFOUNDATION_LIBRARY})
+endif()
+
 add_library(${PROJECT_NAME}::HWinfo ALIAS HWinfo)
 
 install(TARGETS HWinfo DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/apple/battery.cpp
+++ b/src/apple/battery.cpp
@@ -5,40 +5,136 @@
 
 #ifdef HWINFO_APPLE
 
+#include <IOKit/ps/IOPSKeys.h>
+#include <IOKit/ps/IOPowerSources.h>
+
+#include <iostream>
+
 #include "hwinfo/battery.h"
 
 namespace hwinfo {
 
 // =====================================================================================================================
-// _____________________________________________________________________________________________________________________
-std::string Battery::getVendor() const { return "<unknwon>"; }
+CFDictionaryRef getPowerSource(const int id) {
+  const CFTypeRef powerInfo = IOPSCopyPowerSourcesInfo();
+  if (!powerInfo) {
+    return nullptr;
+  }
+
+  const CFArrayRef powerSources = IOPSCopyPowerSourcesList(powerInfo);
+  if (!powerSources) {
+    CFRelease(powerInfo);
+    return nullptr;
+  }
+
+  const CFDictionaryRef powerSource =
+      IOPSGetPowerSourceDescription(powerInfo, CFArrayGetValueAtIndex(powerSources, id));
+
+  if (!powerSource) {
+    CFRelease(powerSources);
+    CFRelease(powerInfo);
+    return nullptr;
+  }
+
+  CFRetain(powerSource);
+
+  CFRelease(powerSources);
+  CFRelease(powerInfo);
+
+  return powerSource;
+}
 
 // _____________________________________________________________________________________________________________________
-std::string Battery::getModel() const { return "<unknwon>"; }
+std::string Battery::getVendor() const {
+  const CFDictionaryRef powerSource = getPowerSource(_id);
+  if (!powerSource) {
+    return "<unknown>";
+  }
+
+  const auto vendorName = static_cast<CFStringRef>(CFDictionaryGetValue(powerSource, CFSTR(kIOPSVendorDataKey)));
+
+  CFRelease(powerSource);
+  if (!vendorName) {
+    return "<unknown>";
+  }
+
+  const char* vendor = CFStringGetCStringPtr(vendorName, kCFStringEncodingUTF8);
+  return vendor ? std::string(vendor) : "<unknown>";
+}
 
 // _____________________________________________________________________________________________________________________
-std::string Battery::getSerialNumber() const { return "<unknwon>"; }
+std::string Battery::getModel() const { return "<unknown>"; }
 
 // _____________________________________________________________________________________________________________________
-std::string Battery::getTechnology() const { return "<unknwon>"; }
+std::string Battery::getSerialNumber() const { return "<unknown>"; }
 
 // _____________________________________________________________________________________________________________________
-uint32_t Battery::getEnergyFull() const { return 0; }
+std::string Battery::getTechnology() const { return "<unknown>"; }
 
 // _____________________________________________________________________________________________________________________
-uint32_t Battery::energyNow() const { return 0; }
+uint32_t Battery::getEnergyFull() const { return 1; }
 
 // _____________________________________________________________________________________________________________________
-bool Battery::charging() const { return false; }
+uint32_t Battery::energyNow() const {
+  const CFDictionaryRef powerSource = getPowerSource(_id);
+  if (!powerSource) {
+    return 0;
+  }
+
+  const auto currentCapacityNum =
+      static_cast<CFNumberRef>(CFDictionaryGetValue(powerSource, CFSTR(kIOPSCurrentCapacityKey)));
+  CFRelease(powerSource);
+  if (!currentCapacityNum) {
+    return 0;
+  }
+
+  uint32_t currentCapacity;
+  CFNumberGetValue(currentCapacityNum, kCFNumberIntType, &currentCapacity);
+
+  return currentCapacity;
+}
 
 // _____________________________________________________________________________________________________________________
-bool Battery::discharging() const { return false; }
+bool Battery::charging() const {
+  const CFDictionaryRef powerSource = getPowerSource(_id);
+  if (!powerSource) {
+    return "<unknown>";
+  }
+
+  const auto isCharging = static_cast<CFBooleanRef>(CFDictionaryGetValue(powerSource, CFSTR(kIOPSIsChargingKey)));
+
+  return isCharging == kCFBooleanTrue;
+}
+
+// _____________________________________________________________________________________________________________________
+bool Battery::discharging() const { return !charging(); }
 
 // =====================================================================================================================
 // _____________________________________________________________________________________________________________________
 std::vector<Battery> getAllBatteries() {
-  // TODO: implement
-  return {};
+  std::vector<Battery> batteries;
+
+  const CFTypeRef powerInfo = IOPSCopyPowerSourcesInfo();
+  if (!powerInfo) {
+    return batteries;
+  }
+
+  const CFArrayRef powerSources = IOPSCopyPowerSourcesList(powerInfo);
+  if (!powerSources) {
+    CFRelease(powerInfo);
+    return batteries;
+  }
+
+  const int numSources = static_cast<int>(CFArrayGetCount(powerSources));
+
+  CFRelease(powerSources);
+  CFRelease(powerInfo);
+
+  for (int i = 0; i < numSources; ++i) {
+    batteries.emplace_back(i);
+  }
+
+  return batteries;
 }
 
 }  // namespace hwinfo


### PR DESCRIPTION
This PR focuses on implementing the following functions for MacOS:

battery:
- Capacity
- Charging status
- Serial number (not all power sources publish this one)

The README was updated to reflect those changes.

