### PR TITLE
fix: use the latest supported standard instead of forcing C++-11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,21 @@ endif()
 
 set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
-set (CMAKE_CXX_STANDARD 11)
+
+# if standard not provided, use the latest supported by the compiler
+if("${CMAKE_CXX_STANDARD}" STREQUAL "")
+  function(_set_language_standard output language)
+    foreach(version IN LISTS ARGN)
+      if(DEFINED "CMAKE_${language}${version}_STANDARD_COMPILE_OPTION"
+        OR DEFINED "CMAKE_${language}${version}_EXTENSION_COMPILE_OPTION"
+      )
+        set("${output}" "${version}" PARENT_SCOPE)
+        break()
+      endif()
+    endforeach()
+  endfunction()
+  _set_language_standard(CMAKE_CXX_STANDARD CXX 20 17 14 11)
+endif()
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION

Previously hwinfo forced C++-11 for all the users. This changes this so that if the default CMAKE_CXX_STANDARD is not set, detect the latest CXX standard supported by the compiler and use it. If someone needs an older standard like c++11 although their compiler supports c++20, they can override this by passing -D CMAKE_CXX_STANDARD=11.

Based on https://github.com/aminya/project_options/blob/ca3ecdcda321940a6ecb6552b665950bba49756a/src/Standards.cmake
