### PR TITLE
FIX: wstring_to_std_string issue

### DIFF
--- a/include/hwinfo/utils/stringutils.h
+++ b/include/hwinfo/utils/stringutils.h
@@ -180,7 +180,13 @@ inline std::string wstring_to_string() { return ""; }
  * @return
  */
 inline std::string wstring_to_std_string(const std::wstring& ws) {
-  std::string str_locale = std::setlocale(LC_ALL, "");
+  std::string str_locale = std::setlocale(LC_ALL, NULL);
+
+#if _MSC_VER
+  std::setlocale(LC_ALL, ".65001");
+#else
+  std::setlocale(LC_ALL, ".UTF-8");
+#endif
   const wchar_t* wch_src = ws.c_str();
 
 #ifdef _MSC_VER


### PR DESCRIPTION
The function wstring_to_std_string does not correctly convert wstring to UTF-8 encoded string, which causes a crash when fmt prints strings in system_infoMain.cpp later on.