### PR TITLE
Mac: os: add build version and endianess check

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ CPU, RAM, GPU, Disks, Mainboard, ...
 |                  | Frequency          |  ✔️   |  ❌️   |   ✔️    |
 |                  | Physical Cores     |  ✔️   |  ✔️   |   ✔️    |
 |                  | Logical Cores      |  ✔️   |  ✔️   |   ✔️    |
-|                  | Cache Size         |  ✔️   |  ❌️   |   ✔️    |
+|                  | Cache Size         |  ✔️   |  ✔️️  |   ✔️    |
 | GPU              | Vendor             |  ✔️   |  ❌️   |   ✔️    |
 |                  | Model              |  ✔️   |  ❌️   |   ✔️    |
 |                  | Memory Size        |   ❌   |   ❌   |   ✔️    |
@@ -51,7 +51,7 @@ CPU, RAM, GPU, Disks, Mainboard, ...
 |                  | Name               |   ❌   |   ❌   |   ✔️    |
 |                  | Serial Number      |   ❌   |   ❌   |   ✔️    |
 |                  | Total Memory Size  |  ✔️   |  ✔️   |   ✔️    |
-|                  | Free Memory Size   |  ✔️   |  ✔️   |   ✔️    |
+|                  | Free Memory Size   |  ✔️   |   ❌   |   ✔️    |
 | Mainboard        | Vendor             |  ✔️   |   ❌   |   ✔️    |
 |                  | Model              |  ✔️   |   ❌   |   ✔️    |
 |                  | Version            |  ✔️   |   ❌   |   ✔️    |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ CPU, RAM, GPU, Disks, Mainboard, ...
 
 | Component        | Info               | Linux | Apple | Windows |
 |------------------|:-------------------|:-----:|:-----:|:-------:|
-| CPU              | Vendor             |  ✔️   |  ❌️   |   ✔️    |
+| CPU              | Vendor             |  ✔️   |  ✔️   |   ✔️    |
 |                  | Model              |  ✔️   |  ✔️   |   ✔️    |
 |                  | Frequency          |  ✔️   |  ❌️   |   ✔️    |
 |                  | Physical Cores     |  ✔️   |  ✔️   |   ✔️    |
@@ -51,11 +51,11 @@ CPU, RAM, GPU, Disks, Mainboard, ...
 |                  | Name               |   ❌   |   ❌   |   ✔️    |
 |                  | Serial Number      |   ❌   |   ❌   |   ✔️    |
 |                  | Total Memory Size  |  ✔️   |  ✔️   |   ✔️    |
-|                  | Free Memory Size   |  ✔️   |   ❌   |   ✔️    |
+|                  | Free Memory Size   |  ✔️   |  ✔️   |   ✔️    |
 | Mainboard        | Vendor             |  ✔️   |   ❌   |   ✔️    |
 |                  | Model              |  ✔️   |   ❌   |   ✔️    |
 |                  | Version            |  ✔️   |   ❌   |   ✔️    |
-|                  | Serial-Number      |   ❌   |   ❌   |   ✔️    |
+|                  | Serial-Number      |   ❌   |  ✔️   |   ✔️    |
 |                  | Bios               |   ❌   |   ❌   |    ❌    |
 | Disk             | Vendor             |  ✔️   |  ✔️   |   ✔️    |
 |                  | Model              |  ✔️   |  ✔️   |   ✔️    |

--- a/src/apple/cpu.cpp
+++ b/src/apple/cpu.cpp
@@ -267,7 +267,9 @@ std::string getModelName() {
   }
   return model;
 #else
-  return utils::getSysctlString("machdep.cpu.brand_string", "<unknown>");
+  std::string name = utils::getSysctlString("machdep.cpu.brand_string", "<unknown>");
+  name.pop_back();
+  return name;
 #endif
 }
 

--- a/src/apple/cpu.cpp
+++ b/src/apple/cpu.cpp
@@ -267,7 +267,7 @@ std::string getModelName() {
   }
   return model;
 #else
-  std::string name = utils::getSysctlString("machdep.cpu.brand_string", "<unknown>");
+  std::string name = utils::getSysctlString("machdep.cpu.brand_string", "<unknown> ");
   name.pop_back();
   return name;
 #endif

--- a/src/apple/os.cpp
+++ b/src/apple/os.cpp
@@ -17,15 +17,15 @@ OS::OS() {
   _name = "macOS";
 
   // Get kernel name and version
-  _kernel = utils::getSysctlString("kern.ostype", "<unknown name>");
+  _kernel = utils::getSysctlString("kern.ostype", "<unknown name> ");
   _kernel.pop_back();
-  _kernel = _kernel + " " + utils::getSysctlString("kern.osrelease", "<unknown version>");
+  _kernel = _kernel + " " + utils::getSysctlString("kern.osrelease", "<unknown version> ");
   _kernel.pop_back();
 
   // get OS name and build version
-  _version = utils::getSysctlString("kern.osproductversion", "<unknown>");
+  _version = utils::getSysctlString("kern.osproductversion", "<unknown> ");
   _version.pop_back();
-  _version = _version + " (" + utils::getSysctlString("kern.osversion", "<unknown build>");
+  _version = _version + " (" + utils::getSysctlString("kern.osversion", "<unknown build> ");
   _version.pop_back();
   _version = _version + ")";
 

--- a/src/apple/os.cpp
+++ b/src/apple/os.cpp
@@ -7,7 +7,6 @@
 
 #include <sys/sysctl.h>
 
-#include <iostream>
 #include <sstream>
 #include <string>
 

--- a/src/apple/os.cpp
+++ b/src/apple/os.cpp
@@ -5,9 +5,6 @@
 
 #ifdef HWINFO_APPLE
 
-#include <sys/sysctl.h>
-
-#include <sstream>
 #include <string>
 
 #include "hwinfo/os.h"

--- a/src/apple/os.cpp
+++ b/src/apple/os.cpp
@@ -7,6 +7,7 @@
 
 #include <sys/sysctl.h>
 
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -51,6 +52,20 @@ OS::OS() {
     _version = os_version;
   } else {
     _version = "<unknown>";
+  }
+
+  if (sysctlbyname("kern.osversion", static_cast<void*>(const_cast<char*>(os_version.data())), &size, nullptr, 0) ==
+      0) {
+    os_version.resize(size);
+    os_version.pop_back();
+    _version = _version + " (" + os_version + ")";
+  }
+
+  int byteorder = 0;
+  size_t order_size = sizeof(byteorder);
+  if (sysctlbyname("hw.byteorder", &byteorder, &order_size, nullptr, 0) == 0) {
+    _bigEndian = (byteorder == 4321);
+    _littleEndian = (byteorder == 1234);
   }
 
   _64bit = true;


### PR DESCRIPTION
This PR introduces the following changes:

cpu:
- remove non-printable character at the end of the model output

os:
- add build version
- implement endianess check 
- refactor to use sysctl utils introduced in earlier PR

README:
- update README to reflect recent changes