### PR TITLE
Several MinGW compilation issue fixes.

### DIFF
--- a/include/hwinfo/utils/wmi_wrapper.h
+++ b/include/hwinfo/utils/wmi_wrapper.h
@@ -4,7 +4,7 @@
 
 #ifdef HWINFO_WINDOWS
 
-#include <WbemIdl.h>
+#include <wbemidl.h>
 #include <comdef.h>
 
 #include <iostream>

--- a/src/apple/gpu.cpp
+++ b/src/apple/gpu.cpp
@@ -10,13 +10,30 @@
 #include <vector>
 
 #include "hwinfo/gpu.h"
+#import <Metal/Metal.h>
 
 namespace hwinfo {
 
 // _____________________________________________________________________________________________________________________
 std::vector<GPU> getAllGPUs() {
+  NSArray<id<MTLDevice>>* devices = MTLCopyAllDevices();
+
   std::vector<GPU> gpus{};
-  // TODO: implement
+  for (id<MTLDevice> device in devices) {
+    GPU gpu;
+    gpu._name = std::string{[device.name UTF8String], device.name.length};
+    if (@available(macos 14.0, ios 16.0, *)) {
+      gpu._vendor = "Apple " + std::string{[device.architecture.name UTF8String], device.architecture.name.length};
+    } else {
+      gpu._vendor = "?";
+    }
+    gpu._memory_Bytes = device.recommendedMaxWorkingSetSize;
+    gpu._vendor_id = "?";
+    gpu._device_id = device.registryID;
+
+    // there is not cache_size and max_frequency in MTLDevice
+    gpus.push_back(std::move(gpu));
+  }
   return gpus;
 }
 

--- a/src/linux/disk.cpp
+++ b/src/linux/disk.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <regex>
 #include <vector>
+#include <sstream>
 
 namespace {
 

--- a/src/linux/gpu.cpp
+++ b/src/linux/gpu.cpp
@@ -71,6 +71,7 @@ std::vector<GPU> getAllGPUs() {
     }
     gpu._vendor_id = read_drm_by_path(path + "device/vendor");
     gpu._device_id = read_drm_by_path(path + "device/device");
+    gpu._driverVersion = read_drm_by_path(path + "device/driver/module/version");
     if (gpu._vendor_id.empty() || gpu._device_id.empty()) {
       id++;
       continue;

--- a/src/windows/os.cpp
+++ b/src/windows/os.cpp
@@ -4,7 +4,7 @@
 #include <hwinfo/platform.h>
 
 #ifdef HWINFO_WINDOWS
-#include <Windows.h>
+#include <windows.h>
 
 #include <sstream>
 #include <string>

--- a/src/windows/ram.cpp
+++ b/src/windows/ram.cpp
@@ -4,7 +4,7 @@
 #include <hwinfo/platform.h>
 
 #ifdef HWINFO_WINDOWS
-#include <Windows.h>
+#include <windows.h>
 #include <hwinfo/ram.h>
 #include <hwinfo/utils/stringutils.h>
 #include <hwinfo/utils/wmi_wrapper.h>

--- a/src/windows/utils/wmi_wrapper.cpp
+++ b/src/windows/utils/wmi_wrapper.cpp
@@ -16,7 +16,7 @@ _WMI::_WMI() {
   res &= CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);
   res &= CoCreateInstance(CLSID_WbemLocator, nullptr, CLSCTX_INPROC_SERVER, IID_IWbemLocator, (LPVOID*)&locator);
   if (locator) {
-    res &= locator->ConnectServer(_bstr_t("ROOT\\CIMV2"), nullptr, nullptr, nullptr, 0, nullptr, nullptr, &service);
+    res &= locator->ConnectServer(_bstr_t(L"ROOT\\CIMV2"), nullptr, nullptr, nullptr, 0, nullptr, nullptr, &service);
     if (service)
       res &= CoSetProxyBlanket(service, RPC_C_AUTHN_WINNT, RPC_C_AUTHZ_NONE, nullptr, RPC_C_AUTHN_LEVEL_CALL,
                                RPC_C_IMP_LEVEL_IMPERSONATE, nullptr, EOAC_NONE);


### PR DESCRIPTION
Windows has a case-insensitive file system, but it seems the header files actually have a small-case spelling.

feat(macos): Implement MTLDevice detection.
feat(linux): Get GPU driver version without OpenCL.
fix(build): Windows headers are small letter.
fix(build): Some Windows API use wchar_t.
fix(build): Add include for <sstream>