### PR TITLE
macOS: add marketing name

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CPU, RAM, GPU, Disks, Mainboard, ...
 |                  | Free Size          |  ✔️   |  ✔️   |   ✔️    |
 |                  | Volumes            |  ✔️   |  ✔️   |   ✔️    |
 | Operating System | Name               |  ✔️   |  ✔️   |   ✔️    |
-|                  | Short Name         |  ✔️   |  ❌️   |   ✔️    |
+|                  | Short Name         |  ✔️   |  ✔️   |   ✔️    |
 |                  | Version            |  ✔️   |  ✔️   |    ❌    |
 |                  | Kernel             |  ✔️   |  ✔️   |    ❌    |
 |                  | Architecture (Bit) |  ✔️   |  ✔️   |   ✔️    |
@@ -82,6 +82,7 @@ link against depending on your needs.
 ```cmake
 target_link_libraries(your_target PRIVATE hwinfo::hwinfo)
 ```
+
 or
 
 ```cmake

--- a/src/apple/os.cpp
+++ b/src/apple/os.cpp
@@ -12,6 +12,84 @@
 
 namespace hwinfo {
 
+std::string getMarketingName(const std::string& version) {
+  size_t dotPos = version.find('.');
+  if (dotPos == std::string::npos) {
+    return "";
+  }
+
+  int majorVersion = 0;
+  try {
+    majorVersion = std::stoi(version.substr(0, dotPos));
+  } catch (...) {
+    return "";
+  }
+
+  // map major version to marketing name
+  switch (majorVersion) {
+    case 26:
+      return "Tahoe";
+    case 15:
+      return "Sequoia";
+    case 14:
+      return "Sonoma";
+    case 13:
+      return "Ventura";
+    case 12:
+      return "Monterey";
+    case 11:
+      return "Big Sur";
+    case 10: {
+      // handle 10.x versions - need to check minor version
+      size_t secondDot = version.find('.', dotPos + 1);
+      std::string minorStr = (secondDot != std::string::npos) ? version.substr(dotPos + 1, secondDot - dotPos - 1)
+                                                              : version.substr(dotPos + 1);
+      try {
+        switch (std::stoi(minorStr)) {
+          case 15:
+            return "Catalina";
+          case 14:
+            return "Mojave";
+          case 13:
+            return "High Sierra";
+          case 12:
+            return "Sierra";
+          case 11:
+            return "El Capitan";
+          case 10:
+            return "Yosemite";
+          case 9:
+            return "Mavericks";
+          case 8:
+            return "Mountain Lion";
+          case 7:
+            return "Lion";
+          case 6:
+            return "Snow Leopard";
+          case 5:
+            return "Leopard";
+          case 4:
+            return "Tiger";
+          case 3:
+            return "Panther";
+          case 2:
+            return "Jaguar";
+          case 1:
+            return "Puma";
+          case 0:
+            return "Cheetah";
+          default:
+            return "";
+        }
+      } catch (...) {
+        return "";
+      }
+    }
+    default:
+      return "";
+  }
+}
+
 // _____________________________________________________________________________________________________________________
 OS::OS() {
   _name = "macOS";
@@ -25,6 +103,12 @@ OS::OS() {
   // get OS name and build version
   _version = utils::getSysctlString("kern.osproductversion", "<unknown> ");
   _version.pop_back();
+
+  // add marketing name if we can determine it
+  if (std::string marketingName = getMarketingName(_version); !marketingName.empty()) {
+    _name = _name + " " + marketingName;
+  }
+
   _version = _version + " (" + utils::getSysctlString("kern.osversion", "<unknown build> ");
   _version.pop_back();
   _version = _version + ")";


### PR DESCRIPTION
This PR adds a lookup function on macOS marketing names.

Apparently, Apple does not expose this name at all (shame on Apple!), so a lookup function is the only way.