### PR TITLE
Modification to compile with MinGW 13.1 as dll

### DIFF
--- a/include/hwinfo/battery.h
+++ b/include/hwinfo/battery.h
@@ -13,8 +13,8 @@
 namespace hwinfo {
 
 class HWINFO_API Battery {
-  friend std::vector<Battery> getAllBatteries();
-  friend std::ostream& operator<<(std::ostream& os, const Battery& battery);
+  friend std::vector<Battery> HWINFO_API getAllBatteries();
+  friend HWINFO_API std::ostream& operator<<(std::ostream& os, const Battery& battery);
 
  public:
   static constexpr std::uint32_t invalid_id = std::numeric_limits<std::uint32_t>::max();

--- a/include/hwinfo/battery.h
+++ b/include/hwinfo/battery.h
@@ -50,9 +50,9 @@ class HWINFO_API Battery {
   uint32_t _energyFull = 0;
 };
 
-std::vector<Battery> getAllBatteries();
+std::vector<Battery> HWINFO_API getAllBatteries();
 
-std::ostream& operator<<(std::ostream& os, const Battery::State& state);
-std::ostream& operator<<(std::ostream& os, const Battery& battery);
+HWINFO_API std::ostream& operator<<(std::ostream& os, const Battery::State& state);
+HWINFO_API std::ostream& operator<<(std::ostream& os, const Battery& battery);
 
 }  // namespace hwinfo

--- a/include/hwinfo/cpu.h
+++ b/include/hwinfo/cpu.h
@@ -26,7 +26,7 @@ std::vector<int64_t> current_frequency_hz();
 }  // namespace monitor::cpu
 
 class HWINFO_API CPU {
-  friend std::vector<CPU> getAllCPUs();
+  friend std::vector<CPU> HWINFO_API getAllCPUs();
 
  public:
   static constexpr std::uint32_t invalid_id = std::numeric_limits<std::uint32_t>::max();

--- a/include/hwinfo/cpu.h
+++ b/include/hwinfo/cpu.h
@@ -69,6 +69,6 @@ class HWINFO_API CPU {
   std::vector<Core> _cores;
 };
 
-std::vector<CPU> getAllCPUs();
+std::vector<CPU> HWINFO_API getAllCPUs();
 
 }  // namespace hwinfo

--- a/include/hwinfo/disk.h
+++ b/include/hwinfo/disk.h
@@ -30,8 +30,8 @@ class HWINFO_API Disk {
     UNKNOWN
   };
 
-  friend std::vector<Disk> getAllDisks();
-  friend std::ostream& operator<<(std::ostream& os, const Disk::Interface& disk_interface);
+  friend std::vector<Disk> HWINFO_API getAllDisks();
+  friend HWINFO_API std::ostream& operator<<(std::ostream& os, const Disk::Interface& disk_interface);
   friend std::ostream& operator<<(std::ostream& os, const Disk& disk);
 
  public:

--- a/include/hwinfo/disk.h
+++ b/include/hwinfo/disk.h
@@ -60,8 +60,8 @@ class HWINFO_API Disk {
   Interface _interface = Interface::UNKNOWN;
 };
 
-std::vector<Disk> getAllDisks();
+std::vector<Disk> HWINFO_API getAllDisks();
 
-std::ostream& operator<<(std::ostream& os, const hwinfo::Disk::Interface& disk_interface);
+HWINFO_API std::ostream& operator<<(std::ostream& os, const hwinfo::Disk::Interface& disk_interface);
 
 }  // namespace hwinfo

--- a/include/hwinfo/gpu.h
+++ b/include/hwinfo/gpu.h
@@ -48,6 +48,6 @@ class HWINFO_API GPU {
   std::string _device_id;
 };
 
-std::vector<GPU> getAllGPUs();
+std::vector<GPU> HWINFO_API getAllGPUs();
 
 }  // namespace hwinfo

--- a/include/hwinfo/gpu.h
+++ b/include/hwinfo/gpu.h
@@ -13,7 +13,7 @@
 namespace hwinfo {
 
 class HWINFO_API GPU {
-  friend std::vector<GPU> getAllGPUs();
+  friend std::vector<GPU> HWINFO_API getAllGPUs();
 
  public:
   static constexpr std::uint32_t invalid_id = std::numeric_limits<std::uint32_t>::max();

--- a/include/hwinfo/monitoring/cpu.h
+++ b/include/hwinfo/monitoring/cpu.h
@@ -10,7 +10,7 @@ using namespace std::chrono_literals;
 
 namespace hwinfo::monitoring::cpu {
 
-struct Data {
+struct HWINFO_API Data {
   double utilization;                       // average across all threads [0, 1]
   std::vector<double> thread_utilization;   // per-thread utilization [0, 1]
   std::vector<int64_t> thread_frequency_hz; // per-thread current clock rate in Hz
@@ -28,7 +28,7 @@ std::vector<double> thread_utilization(std::chrono::milliseconds sleep = 200ms);
 std::vector<int64_t> thread_frequency_hz();
 
 // Fetches a complete Data snapshot. Blocks for `sleep` milliseconds.
-Data fetch(std::chrono::milliseconds sleep = 200ms);
+Data HWINFO_API fetch(std::chrono::milliseconds sleep = 200ms);
 
 using Monitor = hwinfo::monitoring::Monitor<Data>;
 

--- a/include/hwinfo/monitoring/cpu.h
+++ b/include/hwinfo/monitoring/cpu.h
@@ -11,9 +11,9 @@ using namespace std::chrono_literals;
 namespace hwinfo::monitoring::cpu {
 
 struct HWINFO_API Data {
-  double utilization;                       // average across all threads [0, 1]
-  std::vector<double> thread_utilization;   // per-thread utilization [0, 1]
-  std::vector<int64_t> thread_frequency_hz; // per-thread current clock rate in Hz
+  double utilization;                        // average across all threads [0, 1]
+  std::vector<double> thread_utilization;    // per-thread utilization [0, 1]
+  std::vector<int64_t> thread_frequency_hz;  // per-thread current clock rate in Hz
 };
 
 // Returns average CPU utilization across all logical threads [0, 1].

--- a/include/hwinfo/monitoring/disk.h
+++ b/include/hwinfo/monitoring/disk.h
@@ -8,7 +8,7 @@
 
 namespace hwinfo::monitoring::disk {
 
-struct Data {
+struct HWINFO_API Data {
   std::string mount_point;
   uint64_t free_bytes;
 };
@@ -20,7 +20,7 @@ std::uint64_t get_free_size(const std::string& mount_point);
 std::uint64_t get_free_size(const Disk& disk);
 
 // Fetches a Data snapshot for a single mount point.
-Data fetch(const std::string& mount_point);
+Data HWINFO_API fetch(const std::string& mount_point);
 
 using Monitor = hwinfo::monitoring::Monitor<Data>;
 

--- a/include/hwinfo/monitoring/ram.h
+++ b/include/hwinfo/monitoring/ram.h
@@ -7,8 +7,8 @@
 namespace hwinfo::monitoring::ram {
 
 struct HWINFO_API Data {
-  uint64_t free_bytes;      // memory not in use at all
-  uint64_t available_bytes; // memory available for new allocations (includes reclaimable)
+  uint64_t free_bytes;       // memory not in use at all
+  uint64_t available_bytes;  // memory available for new allocations (includes reclaimable)
 };
 
 // Returns free physical memory in bytes.

--- a/include/hwinfo/monitoring/ram.h
+++ b/include/hwinfo/monitoring/ram.h
@@ -6,7 +6,7 @@
 
 namespace hwinfo::monitoring::ram {
 
-struct Data {
+struct HWINFO_API Data {
   uint64_t free_bytes;      // memory not in use at all
   uint64_t available_bytes; // memory available for new allocations (includes reclaimable)
 };
@@ -18,7 +18,7 @@ uint64_t free_bytes();
 uint64_t available_bytes();
 
 // Fetches a complete Data snapshot.
-Data fetch();
+Data HWINFO_API fetch();
 
 using Monitor = hwinfo::monitoring::Monitor<Data>;
 

--- a/include/hwinfo/network.h
+++ b/include/hwinfo/network.h
@@ -29,6 +29,6 @@ class HWINFO_API Network {
   std::string _ip6;
 };
 
-std::vector<Network> getAllNetworks();
+std::vector<Network> HWINFO_API getAllNetworks();
 
 }  // namespace hwinfo

--- a/include/hwinfo/network.h
+++ b/include/hwinfo/network.h
@@ -8,7 +8,7 @@
 namespace hwinfo {
 
 class HWINFO_API Network {
-  friend std::vector<Network> getAllNetworks();
+  friend std::vector<Network> HWINFO_API getAllNetworks();
 
  public:
   ~Network() = default;

--- a/include/hwinfo/platform.h
+++ b/include/hwinfo/platform.h
@@ -37,7 +37,9 @@
 #else
 #define HWINFO_API __declspec(dllimport)
 #endif
+#ifndef __MINGW32__
 #pragma warning(disable : 4251)
+#endif
 #else
 #define HWINFO_API __attribute__((visibility("default")))
 #endif

--- a/include/hwinfo/utils/wmi_wrapper.h
+++ b/include/hwinfo/utils/wmi_wrapper.h
@@ -10,7 +10,9 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#ifndef __MINGW32__
 #pragma comment(lib, "wbemuuid.lib")
+#endif
 
 namespace hwinfo {
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -59,6 +59,9 @@ if (HWINFO_CPU)
     endif()
     target_include_directories(hwinfo_cpu PUBLIC $<BUILD_INTERFACE:${HWINFO_INCLUDE_DIR}> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+    if(MINGW)
+        target_link_libraries(hwinfo_cpu PUBLIC PowrProf ntdll)
+    endif()
     target_link_libraries(hwinfo INTERFACE hwinfo_cpu)
 
     set_target_properties(hwinfo_cpu PROPERTIES OUTPUT_NAME "hwinfo_cpu")
@@ -143,6 +146,9 @@ if (HWINFO_GPU)
     target_include_directories(hwinfo_gpu PUBLIC $<BUILD_INTERFACE:${HWINFO_INCLUDE_DIR}> $<BUILD_INTERFACE:${HWINFO_CMAKE_BINARY_DIR}/generated> $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     add_dependencies(hwinfo_gpu generate_pci_ids_header)
 
+    if(MINGW)
+        target_link_libraries(hwinfo_gpu PUBLIC dxgi setupapi)
+    endif()
     target_link_libraries(hwinfo INTERFACE hwinfo_gpu)
 
     set_target_properties(hwinfo_gpu PROPERTIES OUTPUT_NAME "hwinfo_gpu")
@@ -179,6 +185,9 @@ if (HWINFO_MAINBOARD)
         target_link_libraries(hwinfo_mainboard PRIVATE "-framework IOKit" "-framework CoreFoundation")
     endif()
 
+    if(MINGW)
+        target_link_libraries(hwinfo_mainboard PUBLIC wbemuuid)
+    endif()
     target_link_libraries(hwinfo INTERFACE hwinfo_mainboard)
 
     set_target_properties(hwinfo_mainboard PROPERTIES OUTPUT_NAME "hwinfo_mainboard")

--- a/src/apple/monitoring/disk.cpp
+++ b/src/apple/monitoring/disk.cpp
@@ -9,7 +9,7 @@
 namespace hwinfo::monitoring::disk {
 
 std::uint64_t get_free_size(const std::string& mount_point) {
-  struct statvfs stat {};
+  struct statvfs stat{};
   if (statvfs(mount_point.c_str(), &stat) == 0) {
     return static_cast<uint64_t>(stat.f_bavail) * static_cast<uint64_t>(stat.f_frsize);
   }
@@ -24,9 +24,7 @@ std::uint64_t get_free_size(const Disk& disk) {
   return total;
 }
 
-Data fetch(const std::string& mount_point) {
-  return Data{mount_point, get_free_size(mount_point)};
-}
+Data fetch(const std::string& mount_point) { return Data{mount_point, get_free_size(mount_point)}; }
 
 }  // namespace hwinfo::monitoring::disk
 

--- a/src/linux/monitoring/cpu.cpp
+++ b/src/linux/monitoring/cpu.cpp
@@ -32,8 +32,7 @@ Jiffies get_jiffies(int index) {
   if (!std::getline(f, line)) return {};
 
   std::istringstream iss(line);
-  std::vector<std::string> parts(std::istream_iterator<std::string>{iss},
-                                  std::istream_iterator<std::string>{});
+  std::vector<std::string> parts(std::istream_iterator<std::string>{iss}, std::istream_iterator<std::string>{});
   if (parts.size() < 11) return {};
 
   int64_t v[10]{};
@@ -93,8 +92,7 @@ std::vector<int64_t> thread_frequency_hz() {
 Data fetch(std::chrono::milliseconds sleep) {
   auto tu = thread_utilization(sleep);
   auto tf = thread_frequency_hz();
-  const double avg =
-      tu.empty() ? 0.0 : std::accumulate(tu.begin(), tu.end(), 0.0) / static_cast<double>(tu.size());
+  const double avg = tu.empty() ? 0.0 : std::accumulate(tu.begin(), tu.end(), 0.0) / static_cast<double>(tu.size());
   return Data{avg, std::move(tu), std::move(tf)};
 }
 

--- a/src/linux/monitoring/disk.cpp
+++ b/src/linux/monitoring/disk.cpp
@@ -9,7 +9,7 @@
 namespace hwinfo::monitoring::disk {
 
 std::uint64_t get_free_size(const std::string& mount_point) {
-  struct statvfs stat {};
+  struct statvfs stat{};
   if (statvfs(mount_point.c_str(), &stat) == 0) {
     return static_cast<uint64_t>(stat.f_bavail) * static_cast<uint64_t>(stat.f_frsize);
   }
@@ -24,9 +24,7 @@ std::uint64_t get_free_size(const Disk& disk) {
   return total;
 }
 
-Data fetch(const std::string& mount_point) {
-  return Data{mount_point, get_free_size(mount_point)};
-}
+Data fetch(const std::string& mount_point) { return Data{mount_point, get_free_size(mount_point)}; }
 
 }  // namespace hwinfo::monitoring::disk
 

--- a/src/linux/os.cpp
+++ b/src/linux/os.cpp
@@ -48,7 +48,7 @@ OS::OS() {
     }
   }
   {  // architecture
-    struct stat buffer {};
+    struct stat buffer{};
     _64bit = stat("/lib64/ld-linux-x86-64.so.2", &buffer) == 0;
     _32bit = !_64bit;
   }

--- a/src/windows/battery.cpp
+++ b/src/windows/battery.cpp
@@ -34,7 +34,7 @@ std::vector<Battery> getAllBatteries() {
   IWbemClassObject* obj = nullptr;
   int battery_id = 0;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }

--- a/src/windows/cpu.cpp
+++ b/src/windows/cpu.cpp
@@ -17,8 +17,10 @@
 #include <thread>
 #include <vector>
 
+#ifndef __MINGW32__
 #pragma comment(lib, "PowrProf.lib")
 #pragma comment(lib, "ntdll.lib")
+#endif
 
 inline int countSetBits(unsigned __int64 mask) {
 #if defined(_M_X64) || defined(__x86_64__)

--- a/src/windows/disk.cpp
+++ b/src/windows/disk.cpp
@@ -83,7 +83,7 @@ std::vector<Disk> getAllDisks() {
     Disk disk;
     disk._id = i;
 
-    STORAGE_PROPERTY_QUERY query = {StorageDeviceProperty, PropertyStandardQuery};
+    STORAGE_PROPERTY_QUERY query = {StorageDeviceProperty, PropertyStandardQuery, 0};
     char buffer[1024];
     DWORD bytesReturned;
     if (DeviceIoControl(hDevice, IOCTL_STORAGE_QUERY_PROPERTY, &query, sizeof(query), &buffer, sizeof(buffer),

--- a/src/windows/gpu.cpp
+++ b/src/windows/gpu.cpp
@@ -14,8 +14,10 @@
 
 #include "hwinfo/gpu.h"
 #include "hwinfo/utils/stringutils.h"
+#ifndef __MINGW32__
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "setupapi.lib")
+#endif
 
 #ifdef USE_OCL
 #include <hwinfo/opencl/device.h>

--- a/src/windows/mainboard.cpp
+++ b/src/windows/mainboard.cpp
@@ -23,7 +23,7 @@ MainBoard::MainBoard() {
   }
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
-  wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+  wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
   if (!u_return) {
     return;
   }

--- a/src/windows/monitoring/cpu.cpp
+++ b/src/windows/monitoring/cpu.cpp
@@ -2,8 +2,8 @@
 
 #ifdef HWINFO_WINDOWS
 
-#include <windows.h>
 #include <powrprof.h>
+#include <windows.h>
 #include <winternl.h>
 
 #include <numeric>
@@ -58,8 +58,7 @@ std::vector<double> thread_utilization(std::chrono::milliseconds sleep) {
     if (total == 0) {
       results.push_back(0.0);
     } else {
-      results.push_back(
-          std::max(0.0, std::min(1.0, 1.0 - static_cast<double>(idle) / static_cast<double>(total))));
+      results.push_back(std::max(0.0, std::min(1.0, 1.0 - static_cast<double>(idle) / static_cast<double>(total))));
     }
   }
   return results;
@@ -92,8 +91,7 @@ std::vector<int64_t> thread_frequency_hz() {
 Data fetch(std::chrono::milliseconds sleep) {
   auto tu = thread_utilization(sleep);
   auto tf = thread_frequency_hz();
-  const double avg =
-      tu.empty() ? 0.0 : std::accumulate(tu.begin(), tu.end(), 0.0) / static_cast<double>(tu.size());
+  const double avg = tu.empty() ? 0.0 : std::accumulate(tu.begin(), tu.end(), 0.0) / static_cast<double>(tu.size());
   return Data{avg, std::move(tu), std::move(tf)};
 }
 

--- a/src/windows/monitoring/cpu.cpp
+++ b/src/windows/monitoring/cpu.cpp
@@ -11,9 +11,10 @@
 #include <vector>
 
 #include "hwinfo/monitoring/cpu.h"
-
+#ifndef __MINGW32__
 #pragma comment(lib, "PowrProf.lib")
 #pragma comment(lib, "ntdll.lib")
+#endif
 
 namespace {
 

--- a/src/windows/monitoring/disk.cpp
+++ b/src/windows/monitoring/disk.cpp
@@ -24,9 +24,7 @@ std::uint64_t get_free_size(const Disk& disk) {
   return size;
 }
 
-Data fetch(const std::string& mount_point) {
-  return Data{mount_point, get_free_size(mount_point)};
-}
+Data fetch(const std::string& mount_point) { return Data{mount_point, get_free_size(mount_point)}; }
 
 }  // namespace hwinfo::monitoring::disk
 

--- a/src/windows/network.cpp
+++ b/src/windows/network.cpp
@@ -1,4 +1,4 @@
-﻿#include "hwinfo/platform.h"
+#include "hwinfo/platform.h"
 
 #ifdef HWINFO_WINDOWS
 
@@ -23,7 +23,7 @@ std::vector<Network> getAllNetworks() {
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }

--- a/src/windows/os.cpp
+++ b/src/windows/os.cpp
@@ -32,7 +32,7 @@ OS::OS() {
   }
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
-  wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+  wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
   if (!u_return) {
     return;
   }

--- a/src/windows/ram.cpp
+++ b/src/windows/ram.cpp
@@ -28,7 +28,7 @@ Memory::Memory() {
   std::vector<Memory> rams;
   int id = 0;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }

--- a/src/windows/utils/wmi_wrapper.cpp
+++ b/src/windows/utils/wmi_wrapper.cpp
@@ -55,7 +55,7 @@ std::vector<long> query(const std::wstring& wmi_class, const std::wstring& field
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }
@@ -96,7 +96,7 @@ std::vector<bool> query(const std::wstring& wmi_class, const std::wstring& field
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }
@@ -128,7 +128,7 @@ std::vector<unsigned> query(const std::wstring& wmi_class, const std::wstring& f
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }
@@ -161,7 +161,7 @@ std::vector<unsigned short> query(const std::wstring& wmi_class, const std::wstr
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }
@@ -193,7 +193,7 @@ std::vector<long long> query(const std::wstring& wmi_class, const std::wstring& 
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }
@@ -226,7 +226,7 @@ std::vector<unsigned long long> query(const std::wstring& wmi_class, const std::
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }
@@ -258,7 +258,7 @@ std::vector<std::string> query(const std::wstring& wmi_class, const std::wstring
   ULONG u_return = 0;
   IWbemClassObject* obj = nullptr;
   while (wmi.enumerator) {
-    wmi.enumerator->Next(WBEM_INFINITE, 1, &obj, &u_return);
+    wmi.enumerator->Next((long)WBEM_INFINITE, 1, &obj, &u_return);
     if (!u_return) {
       break;
     }


### PR DESCRIPTION
Thanks for this great library. 

We wanted to compile with MinGW and found that the current code state does not allow for that. So we made the changes and would propose to integrate them into the main tree: 

This changeset allows to compile hwinfo with MinGW on Windows as a shared library. 

We used MinGW 64Bit version 13.1: 

```
> gcc --version
gcc (x86_64-posix-seh-rev1, Built by MinGW-Builds project) 13.1.0
```

Changes needed: 
- Export declarations for dll-functions (introducing `HWINFO_API`)
- introduce explicit casts to avoid type conversion warnings
- Disable warnings and MSVC pragmas (via `#ifndef __MINGW32__`) for MinGW
- add linking of windows libraries (PowrProf, ntdll, wbemuuid, dxgi setupapi) that seemingly are added automatically on msvc

Testing: 
- Builds on MinGW 13.1
- Have not tested any other platform for regressions. 